### PR TITLE
fix nlopt_srand for 32bit machines

### DIFF
--- a/source/nlopt.d
+++ b/source/nlopt.d
@@ -161,7 +161,18 @@ enum NLOPT_MAXTIME_REACHED = nlopt_result.NLOPT_MAXTIME_REACHED;
 
 extern(System)
 {
-	void nlopt_srand(ulong seed);
+	version(D_X32)
+	{
+		void nlopt_srand(uint seed);
+	}
+	else version(D_LP64)
+	{
+		void nlopt_srand(ulong seed);
+	}
+	else
+	{
+		static assert(0);
+	}
 	void nlopt_srand_time();
 	void nlopt_version(int* major, int* minor, int* bugfix);
 }

--- a/source/nlopt.d
+++ b/source/nlopt.d
@@ -5,6 +5,8 @@ Authors: Chibisi Chima-Okereke
 
 module nlopt;
 
+import core.stdc.config : c_ulong;
+
 extern (C):
 
 alias nlopt_func = double function(uint n, const(double)* x, double* gradient, void* func_data);
@@ -161,18 +163,7 @@ enum NLOPT_MAXTIME_REACHED = nlopt_result.NLOPT_MAXTIME_REACHED;
 
 extern(System)
 {
-	version(D_X32)
-	{
-		void nlopt_srand(uint seed);
-	}
-	else version(D_LP64)
-	{
-		void nlopt_srand(ulong seed);
-	}
-	else
-	{
-		static assert(0);
-	}
+	void nlopt_srand(c_ulong seed);
 	void nlopt_srand_time();
 	void nlopt_version(int* major, int* minor, int* bugfix);
 }


### PR DESCRIPTION
The input type on nlopt_srand needs to account for the difference in 32bit/64bit
machines.

The original C signature of nlopt_srand is
NLOPT_EXTERN(void) nlopt_srand(unsigned long seed);

According to http://wiki.dlang.org/D_binding_for_C
unsigned long only is converted to ulong only on 64bit, but on 32bit it needs
to be uint. 

I'm not completely confident I'm using the correct version() blocks. 
